### PR TITLE
Date Control Default Value

### DIFF
--- a/_controls/date/index.md
+++ b/_controls/date/index.md
@@ -9,7 +9,7 @@ properties:
 
   - title: Default Value
     key: default
-    type: string containing a date
+    type: date (containing a date, eg: 2023-07-09T12:27:13Z)
     default: now
     markdown: true
 


### PR DESCRIPTION
Made it clear that the value for the date controls default value should be of type date, not string.